### PR TITLE
bumps log4j

### DIFF
--- a/graphwebhook/pom.xml
+++ b/graphwebhook/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.4</version>
+		<version>2.6.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -15,6 +15,7 @@
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>17</java.version>
+		<log4j2.version>2.15.0</log4j2.version><!-- TODO remove when spring-boot-starter-parent is upgraded to 2.6.2 or above https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot -->
 	</properties>
 	<dependencies>
 		<dependency>
@@ -56,7 +57,7 @@
 		<dependency>
 			<groupId>com.microsoft.graph</groupId>
 			<artifactId>microsoft-graph</artifactId>
-			<version>5.4.0</version>
+			<version>5.8.0</version>
 		</dependency>
 
 		<dependency>
@@ -88,13 +89,13 @@
 		<dependency>
 			<groupId>com.auth0</groupId>
 			<artifactId>jwks-rsa</artifactId>
-			<version>0.19.0</version>
+			<version>0.20.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk14</artifactId>
-			<version>1.69</version>
+			<version>1.70</version>
 		</dependency>
 	</dependencies>
 
@@ -113,7 +114,7 @@
 			<dependency>
 				<groupId>com.azure.spring</groupId>
 				<artifactId>azure-spring-boot-bom</artifactId>
-				<version>3.6.1</version>
+				<version>3.11.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
bumps log4j at a precaution following the recent CVE but this sample appears not to be impacted by the issue anyway.

https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot