### PR TITLE
ci: adds missing gradle dependencies caching to CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,6 +35,7 @@ jobs:
       with:
         java-version: 21
         distribution: adopt
+        cache: maven
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         java-version: 21
         distribution: adopt
+        cache: maven
     - name: Build with Maven
       working-directory: graphwebhook
       run: mvn package --file pom.xml


### PR DESCRIPTION
related https://www.sonatype.com/blog/maven-central-and-the-tragedy-of-the-commons